### PR TITLE
Correcting the facecolor for Test

### DIFF
--- a/exercises/exercise3/tests/Question 3b.py
+++ b/exercises/exercise3/tests/Question 3b.py
@@ -13,4 +13,4 @@ def test_subplots(env):
   assert(75 <= ylim1[1] <= 80)
   ylim2 = ax2.get_ylim()
   assert(35 <= ylim2[1] <= 40)
-  assert(ax2.patches[0].get_facecolor() == (0.0, 0.0, 0.0, 1.0))  
+  assert(ax2.patches[0].get_facecolor() == (0.0, 0.5019607843137255, 0.0, 1.0))  


### PR DESCRIPTION
# Correction of the Testcase Question 3b
- The test originally had the RGBA of (0.0, 0.0, 0.0, 1.0), which is black. Which causes an error
- But the test needs (0.0, 0.5019607843137255, 0.0, 1.0) because the Histogram is green and not black! 

It was tested and passed the test of Question3b

**General remark:**

- Give the hint that they must store the `plt(..)` if the error is:

```python
DataFrame' object has no attribute 'get_ylim
```

**Specific remark:** 

- Question 3b 

  - The first figure is the histogram for the median salary (like 3a but with Matplotlib).
  - Please delete *(like 3a but with matplotlib).*, because it is misleading. If someone uses the 18 bins, they will get an error because they use 18 bins like in 3a.

- Question 3b - 1 result: 

  ❌ Test case failed

​       Error at line 16 in test Question 3b:

​      assert(ax2.patches[0].get_facecolor() == (0.0, 0.0, 0.0, 1.0)) 

​       AssertionError:

This error is already corrected. If you want to use green, please use the pull request (With the corrected test)! (If you want to use black, then we have to write explicitly black instead of green)

PS: The autograder is implemented and is working! For exercises and the insurance. 